### PR TITLE
Remap 421 (Nametag) to 1 (Stone)

### DIFF
--- a/src/protocolsupport/protocol/v_1_5/remappers/ItemIDRemapper.java
+++ b/src/protocolsupport/protocol/v_1_5/remappers/ItemIDRemapper.java
@@ -93,6 +93,7 @@ public class ItemIDRemapper {
 		replacements[418] = 1;
 		replacements[419] = 1;
 		replacements[420] = 1;
+		replacements[421] = 1;
 	}
 
 	public static int replaceItemId(int oldId) {


### PR DESCRIPTION
Fixes 1.5.2 crash when viewing a nametag, but I didn't test.

EDIT: Tested, 1.5.2 Client doesn't crash anymore.