### PR TITLE
Fix miss disconnect packet for 1.5.2 - 1.6.4

### DIFF
--- a/src/protocolsupport/protocol/transformer/v_1_5/serverboundtransformer/PlayPacketTransformer.java
+++ b/src/protocolsupport/protocol/transformer/v_1_5/serverboundtransformer/PlayPacketTransformer.java
@@ -8,12 +8,14 @@ import java.io.IOException;
 
 import net.minecraft.server.v1_8_R3.BlockPosition;
 import net.minecraft.server.v1_8_R3.ChatComponentText;
+import net.minecraft.server.v1_8_R3.EntityPlayer;
 import net.minecraft.server.v1_8_R3.EnumProtocol;
 import net.minecraft.server.v1_8_R3.EnumProtocolDirection;
 import net.minecraft.server.v1_8_R3.IChatBaseComponent.ChatSerializer;
 import net.minecraft.server.v1_8_R3.Packet;
 import net.minecraft.server.v1_8_R3.PacketListener;
 
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.event.inventory.InventoryType;
 
 import protocolsupport.api.ProtocolVersion;
@@ -250,9 +252,10 @@ public class PlayPacketTransformer implements PacketTransformer {
 				packetdata.writeBytes(buf);
 				break;
 			}
-			case 0xFF: { //No corresponding packet
-				serializer.readString(32767);
-				return new Packet[0];
+			case 0xFF: { //No corresponding packet (PacketClientDisconnect?)
+				EntityPlayer player = ((CraftPlayer) Utils.getPlayer(channel)).getHandle();
+				player.playerConnection.networkManager.close(new ChatComponentText(serializer.readString(32767)));
+				break;
 			}
 		}
 		if (packet != null) {

--- a/src/protocolsupport/protocol/transformer/v_1_6/serverboundtransformer/PlayPacketTransformer.java
+++ b/src/protocolsupport/protocol/transformer/v_1_6/serverboundtransformer/PlayPacketTransformer.java
@@ -8,12 +8,14 @@ import java.io.IOException;
 
 import net.minecraft.server.v1_8_R3.BlockPosition;
 import net.minecraft.server.v1_8_R3.ChatComponentText;
+import net.minecraft.server.v1_8_R3.EntityPlayer;
 import net.minecraft.server.v1_8_R3.EnumProtocol;
 import net.minecraft.server.v1_8_R3.EnumProtocolDirection;
 import net.minecraft.server.v1_8_R3.IChatBaseComponent.ChatSerializer;
 import net.minecraft.server.v1_8_R3.Packet;
 import net.minecraft.server.v1_8_R3.PacketListener;
 
+import org.bukkit.craftbukkit.v1_8_R3.entity.CraftPlayer;
 import org.bukkit.event.inventory.InventoryType;
 
 import protocolsupport.api.ProtocolVersion;
@@ -223,9 +225,10 @@ public class PlayPacketTransformer implements PacketTransformer {
 				packetdata.writeBytes(buf);
 				break;
 			}
-			case 0xFF: { //No corresponding packet
-				serializer.readString(32767);
-				return new Packet[0];
+			case 0xFF: { //No corresponding packet (PacketClientDisconnect?)
+				EntityPlayer player = ((CraftPlayer) Utils.getPlayer(channel)).getHandle();
+				player.playerConnection.networkManager.close(new ChatComponentText(serializer.readString(32767)));
+				break;
 			}
 		}
 		if (packet != null) {


### PR DESCRIPTION
Fixed:
* Missing client disconnect packet for 1.5.2 - 1.6.4

Fix based on: 
MCP 1.8 -> Client -> net.minecraft.client.multiplayer.WorldClient: sendQuittingDisconnectingPacket()