### PR TITLE
Fix chat message

### DIFF
--- a/src/protocolsupport/protocol/transformer/mcpe/packet/mcpe/both/ChatPacket.java
+++ b/src/protocolsupport/protocol/transformer/mcpe/packet/mcpe/both/ChatPacket.java
@@ -37,6 +37,7 @@ public class ChatPacket implements DualPEPacket {
 	public ServerboundPEPacket decode(ByteBuf buf) throws Exception {
 		PacketDataSerializer serializer = new PacketDataSerializer(buf, ProtocolVersion.MINECRAFT_PE);
 		type = TextType.fromNum(serializer.readByte());
+		serializer.readString(); // Nickname
 		switch (type) {
 			case CHAT: {
 				source = serializer.readString();


### PR DESCRIPTION
Fixed:
- Instead of text shows the player's nickname.

Before: https://www.dropbox.com/s/bvoyrvbk3mpv9m0/before.jpg
After:https://www.dropbox.com/s/ean94fssovnodl8/after.jpg