### PR TITLE
[MCPE] Update (and add new) block remappings for MCPE.

### DIFF
--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -112,6 +112,8 @@ public class IdRemapper {
 			// (sticky) piston -> stone
 			registerRemapEntry(29, 1, ProtocolVersionsHelper.MCPE);
 			registerRemapEntry(33, 1, ProtocolVersionsHelper.MCPE);
+			// piston head -> stone
+			registerRemapEntry(34, 1, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -134,6 +134,8 @@ public class IdRemapper {
 			// redstone lamp (on/off) to glowstone
 			registerRemapEntry(124, 89, ProtocolVersionsHelper.MCPE);
 			registerRemapEntry(123, 89, ProtocolVersionsHelper.MCPE);
+			// double oak slab -> double oak slab (MCPE ID remap)
+			registerRemapEntry(125, 157, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -129,6 +129,8 @@ public class IdRemapper {
 			registerRemapEntry(118, 1, ProtocolVersionsHelper.MCPE);
 			// end portal -> nether portal
 			registerRemapEntry(119, 90, ProtocolVersionsHelper.MCPE);
+			// dragon egg -> stone
+			registerRemapEntry(122, 1, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -169,6 +169,14 @@ public class IdRemapper {
 			registerRemapEntry(167, 96, ProtocolVersionsHelper.MCPE);
 			// inverted daylight sensor -> slab
 			registerRemapEntry(178, 158, ProtocolVersionsHelper.MCPE);
+			// red sandstone -> sandstone
+			registerRemapEntry(179, 24, ProtocolVersionsHelper.MCPE);
+			// red sandstone stairs -> sandstone stairs
+			registerRemapEntry(180, 128, ProtocolVersionsHelper.MCPE);
+			// red sandstone doubleslab -> double step
+			registerRemapEntry(181, 43, ProtocolVersionsHelper.MCPE);
+			// red sandstone slab -> step
+			registerRemapEntry(182, 44, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -138,6 +138,8 @@ public class IdRemapper {
 			registerRemapEntry(125, 157, ProtocolVersionsHelper.MCPE);
 			// enderchest -> chest
 			registerRemapEntry(130, 54, ProtocolVersionsHelper.MCPE);
+			// tripwire hook -> sign
+			registerRemapEntry(131, 63, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -104,6 +104,8 @@ public class IdRemapper {
 			registerRemapEntry(197, 64, ProtocolVersionsHelper.MCPE);
 			// standing banner -> standing sign
 			registerRemapEntry(176, 63, ProtocolVersionsHelper.MCPE);
+			// wall banner -> wall sign
+			registerRemapEntry(177, 68, ProtocolVersionsHelper.MCPE);
 			// all buttons -> sign (well, I don't know a better replacer for this)
 			registerRemapEntry(77, 63, ProtocolVersionsHelper.MCPE);
 			registerRemapEntry(143, 63, ProtocolVersionsHelper.MCPE);

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -122,7 +122,9 @@ public class IdRemapper {
 			registerRemapEntry(69, 63, ProtocolVersionsHelper.MCPE);
 			// jukebox -> wood
 			registerRemapEntry(84, 5, ProtocolVersionsHelper.MCPE);
-			
+			// repeater (on/off) -> carpet
+			registerRemapEntry(93, 171, ProtocolVersionsHelper.MCPE);
+			registerRemapEntry(94, 171, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -116,6 +116,8 @@ public class IdRemapper {
 			registerRemapEntry(34, 1, ProtocolVersionsHelper.MCPE);
 			// dispenser -> stone
 			registerRemapEntry(23, 1, ProtocolVersionsHelper.MCPE);
+			// note block -> wood
+			registerRemapEntry(25, 5, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -152,6 +152,9 @@ public class IdRemapper {
 			registerRemapEntry(145, 144, ProtocolVersionsHelper.MCPE);
 			// trapped chest -> chest
 			registerRemapEntry(146, 54, ProtocolVersionsHelper.MCPE);
+			// comparator (on/off) -> carpet
+			registerRemapEntry(149, 171, ProtocolVersionsHelper.MCPE);
+			registerRemapEntry(150, 171, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -125,6 +125,8 @@ public class IdRemapper {
 			// repeater (on/off) -> carpet
 			registerRemapEntry(93, 171, ProtocolVersionsHelper.MCPE);
 			registerRemapEntry(94, 171, ProtocolVersionsHelper.MCPE);
+			// cauldron -> stone
+			registerRemapEntry(118, 1, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -155,6 +155,8 @@ public class IdRemapper {
 			// comparator (on/off) -> carpet
 			registerRemapEntry(149, 171, ProtocolVersionsHelper.MCPE);
 			registerRemapEntry(150, 171, ProtocolVersionsHelper.MCPE);
+			// daylight sensor -> slab
+			registerRemapEntry(151, 158, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -148,10 +148,6 @@ public class IdRemapper {
 			registerRemapEntry(137, 1, ProtocolVersionsHelper.MCPE);
 			// beacon -> nether reactor core
 			registerRemapEntry(138, 247, ProtocolVersionsHelper.MCPE);
-			// mob head -> mob head (MCPE ID remap)
-			registerRemapEntry(144, 143, ProtocolVersionsHelper.MCPE);
-			// anvil -> anvil (MCPE ID remap)
-			registerRemapEntry(145, 144, ProtocolVersionsHelper.MCPE);
 			// trapped chest -> chest
 			registerRemapEntry(146, 54, ProtocolVersionsHelper.MCPE);
 			// comparator (on/off) -> carpet

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -106,9 +106,12 @@ public class IdRemapper {
 			registerRemapEntry(197, 64, ProtocolVersionsHelper.MCPE);
 			// standing banner -> standing sign
 			registerRemapEntry(176, 63, ProtocolVersionsHelper.MCPE);
-			// all buttons -> sign (well, I don't know a better replacer for this)
+			// all buttons -	> sign (well, I don't know a better replacer for this)
 			registerRemapEntry(77, 63, ProtocolVersionsHelper.MCPE);
 			registerRemapEntry(143, 63, ProtocolVersionsHelper.MCPE);
+			// (sticky) piston -> stone
+			registerRemapEntry(29, 1, ProtocolVersionsHelper.MCPE);
+			registerRemapEntry(33, 1, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -159,6 +159,8 @@ public class IdRemapper {
 			registerRemapEntry(151, 158, ProtocolVersionsHelper.MCPE);
 			// hopper -> stone
 			registerRemapEntry(154, 1, ProtocolVersionsHelper.MCPE);
+			// slime block -> stone
+			registerRemapEntry(165, 1, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -131,6 +131,9 @@ public class IdRemapper {
 			registerRemapEntry(119, 90, ProtocolVersionsHelper.MCPE);
 			// dragon egg -> stone
 			registerRemapEntry(122, 1, ProtocolVersionsHelper.MCPE);
+			// redstone lamp (on/off) to glowstone
+			registerRemapEntry(124, 89, ProtocolVersionsHelper.MCPE);
+			registerRemapEntry(123, 89, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -163,6 +163,8 @@ public class IdRemapper {
 			registerRemapEntry(165, 1, ProtocolVersionsHelper.MCPE);
 			// barrier -> invisible bedrock
 			registerRemapEntry(166, 95, ProtocolVersionsHelper.MCPE);
+			// iron trapdoor -> trapdoor
+			registerRemapEntry(167, 96, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -127,6 +127,8 @@ public class IdRemapper {
 			registerRemapEntry(94, 171, ProtocolVersionsHelper.MCPE);
 			// cauldron -> stone
 			registerRemapEntry(118, 1, ProtocolVersionsHelper.MCPE);
+			// end portal -> nether portal
+			registerRemapEntry(119, 90, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -167,6 +167,8 @@ public class IdRemapper {
 			registerRemapEntry(166, 95, ProtocolVersionsHelper.MCPE);
 			// iron trapdoor -> trapdoor
 			registerRemapEntry(167, 96, ProtocolVersionsHelper.MCPE);
+			// inverted daylight sensor -> slab
+			registerRemapEntry(178, 158, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -140,6 +140,8 @@ public class IdRemapper {
 			registerRemapEntry(130, 54, ProtocolVersionsHelper.MCPE);
 			// tripwire hook -> sign
 			registerRemapEntry(131, 63, ProtocolVersionsHelper.MCPE);
+			// tripwire -> air (Because tripwire is a passable block, and there is no replacement for it in MCPE)
+			registerRemapEntry(132, 0, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -114,6 +114,8 @@ public class IdRemapper {
 			registerRemapEntry(33, 1, ProtocolVersionsHelper.MCPE);
 			// piston head -> stone
 			registerRemapEntry(34, 1, ProtocolVersionsHelper.MCPE);
+			// dispenser -> stone
+			registerRemapEntry(23, 1, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -150,6 +150,8 @@ public class IdRemapper {
 			registerRemapEntry(144, 143, ProtocolVersionsHelper.MCPE);
 			// anvil -> anvil (MCPE ID remap)
 			registerRemapEntry(145, 144, ProtocolVersionsHelper.MCPE);
+			// trapped chest -> chest
+			registerRemapEntry(146, 54, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -96,8 +96,6 @@ public class IdRemapper {
 			registerRemapEntry(168, 48, ProtocolVersionsHelper.MCPE);
 			// wood slab -> wood slab (MCPE ID remap)
 			registerRemapEntry(126, 158, ProtocolVersionsHelper.MCPE);
-			// cake -> cake (mystery) (MCPE ID remap)
-			registerRemapEntry(92, 126, ProtocolVersionsHelper.MCPE);
 			// all doors -> door
 			registerRemapEntry(193, 64, ProtocolVersionsHelper.MCPE);
 			registerRemapEntry(194, 64, ProtocolVersionsHelper.MCPE);
@@ -124,6 +122,7 @@ public class IdRemapper {
 			registerRemapEntry(69, 63, ProtocolVersionsHelper.MCPE);
 			// jukebox -> wood
 			registerRemapEntry(84, 5, ProtocolVersionsHelper.MCPE);
+			
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -142,6 +142,8 @@ public class IdRemapper {
 			registerRemapEntry(131, 63, ProtocolVersionsHelper.MCPE);
 			// tripwire -> air (Because tripwire is a passable block, and there is no replacement for it in MCPE)
 			registerRemapEntry(132, 0, ProtocolVersionsHelper.MCPE);
+			// command block -> stone
+			registerRemapEntry(137, 1, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -144,6 +144,8 @@ public class IdRemapper {
 			registerRemapEntry(132, 0, ProtocolVersionsHelper.MCPE);
 			// command block -> stone
 			registerRemapEntry(137, 1, ProtocolVersionsHelper.MCPE);
+			// beacon -> nether reactor core
+			registerRemapEntry(138, 247, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -148,6 +148,8 @@ public class IdRemapper {
 			registerRemapEntry(138, 247, ProtocolVersionsHelper.MCPE);
 			// mob head -> mob head (MCPE ID remap)
 			registerRemapEntry(144, 143, ProtocolVersionsHelper.MCPE);
+			// anvil -> anvil (MCPE ID remap)
+			registerRemapEntry(145, 144, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -136,6 +136,8 @@ public class IdRemapper {
 			registerRemapEntry(123, 89, ProtocolVersionsHelper.MCPE);
 			// double oak slab -> double oak slab (MCPE ID remap)
 			registerRemapEntry(125, 157, ProtocolVersionsHelper.MCPE);
+			// enderchest -> chest
+			registerRemapEntry(130, 54, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -161,6 +161,8 @@ public class IdRemapper {
 			registerRemapEntry(154, 1, ProtocolVersionsHelper.MCPE);
 			// slime block -> stone
 			registerRemapEntry(165, 1, ProtocolVersionsHelper.MCPE);
+			// barrier -> invisible bedrock
+			registerRemapEntry(166, 95, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -106,7 +106,7 @@ public class IdRemapper {
 			registerRemapEntry(197, 64, ProtocolVersionsHelper.MCPE);
 			// standing banner -> standing sign
 			registerRemapEntry(176, 63, ProtocolVersionsHelper.MCPE);
-			// all buttons -	> sign (well, I don't know a better replacer for this)
+			// all buttons -> sign (well, I don't know a better replacer for this)
 			registerRemapEntry(77, 63, ProtocolVersionsHelper.MCPE);
 			registerRemapEntry(143, 63, ProtocolVersionsHelper.MCPE);
 			// (sticky) piston -> stone
@@ -120,6 +120,8 @@ public class IdRemapper {
 			registerRemapEntry(25, 5, ProtocolVersionsHelper.MCPE);
 			// detector rail -> powered rail
 			registerRemapEntry(28, 27, ProtocolVersionsHelper.MCPE);
+			// lever -> sign (well, I don't know a better replacer for this)
+			registerRemapEntry(69, 63, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -146,6 +146,8 @@ public class IdRemapper {
 			registerRemapEntry(137, 1, ProtocolVersionsHelper.MCPE);
 			// beacon -> nether reactor core
 			registerRemapEntry(138, 247, ProtocolVersionsHelper.MCPE);
+			// mob head -> mob head (MCPE ID remap)
+			registerRemapEntry(144, 143, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -157,6 +157,8 @@ public class IdRemapper {
 			registerRemapEntry(150, 171, ProtocolVersionsHelper.MCPE);
 			// daylight sensor -> slab
 			registerRemapEntry(151, 158, ProtocolVersionsHelper.MCPE);
+			// hopper -> stone
+			registerRemapEntry(154, 1, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -122,6 +122,8 @@ public class IdRemapper {
 			registerRemapEntry(28, 27, ProtocolVersionsHelper.MCPE);
 			// lever -> sign (well, I don't know a better replacer for this)
 			registerRemapEntry(69, 63, ProtocolVersionsHelper.MCPE);
+			// jukebox -> wood
+			registerRemapEntry(84, 5, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {

--- a/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
+++ b/src/protocolsupport/protocol/typeremapper/id/IdRemapper.java
@@ -118,6 +118,8 @@ public class IdRemapper {
 			registerRemapEntry(23, 1, ProtocolVersionsHelper.MCPE);
 			// note block -> wood
 			registerRemapEntry(25, 5, ProtocolVersionsHelper.MCPE);
+			// detector rail -> powered rail
+			registerRemapEntry(28, 27, ProtocolVersionsHelper.MCPE);
 		}
 		@Override
 		protected RemappingTable createTable() {


### PR DESCRIPTION
New block remappings for MCPE.

Almost every block (not item, I will do the item remapping when item remapping is working for the MCPE client, so I can test it) remapping is done for MCPE.

Also, some blocks can't be remapped (example: Podzol: MC 1.8.8 ID: 3:1; MCPE ID: 243) and some maybe missing or wrong.

The problem is that the client desyncs from the server a lot, walking? desync. viewing a unremapped block? desync. doing nothing? desync. (And, when it does desync, the only fix is disconnecting the client and kicking it from the console), maybe those desyncs will be fixed as the mcpe branch goes more stable and feature complete :smile: 

Also, IDs are different, I was getting (and comparing) every ID on Minecraft Wiki, however, then I found that some IDs are wrong (when comparing in the PocketMine-MP project: https://github.com/PocketMine/PocketMine-MP/blob/mcpe-0.12/src/pocketmine/item/Item.php#L73 ), so maybe some remappings are wrong.